### PR TITLE
fix: Update to build to include component kstyle_qtcurve5_config popup for QT6

### DIFF
--- a/qt5/config/CMakeLists.txt
+++ b/qt5/config/CMakeLists.txt
@@ -64,5 +64,5 @@ target_link_libraries(kstyle_qtcurve5_config
   KF5::WindowSystem)
 target_link_libraries(kstyle_qtcurve5_config qtcurve-utils)
 
-install(TARGETS kstyle_qtcurve5_config DESTINATION ${_Qt5_PLUGIN_INSTALL_DIR})
+install(TARGETS kstyle_qtcurve5_config DESTINATION ${_Qt5_PLUGIN_INSTALL_DIR}/kstyle_config)
 install(FILES QtCurveui.rc  DESTINATION ${KDE_INSTALL_KXMLGUI5DIR}/QtCurve)

--- a/qt6/config/CMakeLists.txt
+++ b/qt6/config/CMakeLists.txt
@@ -64,5 +64,5 @@ target_link_libraries(kstyle_qtcurve6_config
   KF6::WindowSystem)
 target_link_libraries(kstyle_qtcurve6_config qtcurve-utils)
 
-install(TARGETS kstyle_qtcurve6_config DESTINATION ${_Qt6_PLUGIN_INSTALL_DIR})
+install(TARGETS kstyle_qtcurve6_config DESTINATION ${_Qt6_PLUGIN_INSTALL_DIR}/kstyle_config)
 install(FILES QtCurveui.rc  DESTINATION ${KDE_INSTALL_KXMLGUIDIR}/QtCurve)

--- a/qt6/style/qtcurve.themerc
+++ b/qt6/style/qtcurve.themerc
@@ -73,6 +73,6 @@ Comment[tr]=Çok iyi yapılandırılabilir biçim
 Comment[uk]=Стиль зі значними можливостями із налаштовування
 Comment[zh_CN]=高可配置性的样式
 Comment[zh_TW]=非常可自訂的風格
-ConfigPage=kstyle_qtcurve6_config
+ConfigPage=kstyle_config/kstyle_qtcurve6_config
 [KDE]
 WidgetStyle=QtCurve


### PR DESCRIPTION
I still like and use the QTcurve application style with all the config options. Though it is possible to manually configure the config file, I thought it would be great to get the config panel to work again.
 
The kstyle_qtcurve5_config popup has not been working since the KDE plasma6 update. Here is an update which builds and installs the QT6 version. Initial testing seems to work, though there are many configuration options to work through to prove this is 100%.

 